### PR TITLE
removing unneeded (and now deprecated) call

### DIFF
--- a/dive.rb
+++ b/dive.rb
@@ -3,7 +3,6 @@ class Dive < Formula
   desc "A tool for exploring each layer in a docker image"
   homepage "https://github.com/wagoodman/dive/"
   version "0.9.2"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/wagoodman/dive/releases/download/v0.9.2/dive_0.9.2_darwin_amd64.tar.gz"


### PR DESCRIPTION
Per reports from brew:
```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the wagoodman/dive tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/wagoodman/homebrew-dive/dive.rb:6
```